### PR TITLE
Implemented a LiveCode builder linter.

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -16,16 +16,28 @@ module.exports =
     lcCompilePath:
       type: 'string'
       title: 'Compiler Path For LiveCode Builder'
-      default: 'lc-compile' # Let OS's $PATH handle the rest
+      default: switch
+        when process.platform == 'darwin'
+        then '~/livecode/_build/mac/Debug/lc-compile'
+        when process.platform == 'linux'
+        then '~/livecode/build-linux-x86_64/livecode/out/Debug/lc-compile'
+        when process.platform == 'win32'
+        then '~/livecode/_build/Win32/Debug/lc-compile.exe'
       description: 'Where is your lc-compile installed? ' +
         'Default assumes it\'s on $PATH'
     modulePaths:
       type: 'string'
       title: 'Module Paths For LiveCode Builder'
-      default: '~/livecode/_build/mac/Debug/modules/lci/'
+      default: switch
+        when process.platform == 'darwin'
+        then '~/livecode/_build/mac/Debug/modules/lci/'
+        when process.platform == 'linux'
+        then '~/livecode/build-linux-x86_64/livecode/out/Debug/modules/lci/'
+        when process.platform == 'win32'
+        then '~/livecode/_build/Win32/Debug/modules/lci/'
       description: 'Where are the modules installed? ' +
         'Default is where they should be after building ' +
-        'a debug build of LiveCode on a mac.'
+        'a debug build of LiveCode. Delimit paths with `;`.'
 
   activate: ->
     @subscriptions = new CompositeDisposable

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -79,6 +79,8 @@ module.exports =
         parameters.push(lcCompile)
         lcCompileModulePaths = '-modulePaths=' + @modulePaths
         parameters.push(lcCompileModulePaths)
+        editorFilePath = '-filepath=' + filePath
+        parameters.push(editorFilePath)
         text = textEditor.getText()
         return helpers.exec(command, parameters, {stdin: text}).then (output) ->
           regex = /(\d+),(\d+),(.*)/g

--- a/tools/Linter.lc
+++ b/tools/Linter.lc
@@ -8,7 +8,7 @@ local sTempFile
 Lint
 
 command Lint
-  local tScope, tLCCompile, tModulePaths, theArgument
+  local tScope, tLCCompile, tModulePaths, theArgument, tFilename, tLCIDirectory
 
   local tIndex
   repeat for each element theArgument in the commandArguments
@@ -30,6 +30,13 @@ command Lint
         break
       case "-lcCompile"
         put theArgument[2] into tLCCompile
+        break
+      case "-filepath"
+        set the itemDelimiter to slash
+        put item -1 of theArgument[2] into tFilename
+        put item 1 to -2 of theArgument[2] & "/.lci" into tLCIDirectory
+        put " --modulepath " & tLCIDirectory before tModulePaths
+        set the itemDelimiter to comma
         break
     end switch
   end repeat
@@ -86,8 +93,10 @@ command Lint
       include sTempFile
     break
     case ".source.lcb"
+      if there is not a folder tLCIDirectory then
+        create folder tLCIDirectory
+      end if
       SaveToTempFile tScript
-      local tProcess
       put shell(tLCCompile & tModulePaths & " -- " & sTempFile) into tErrors
       split tErrors with return
       repeat with tIndex = 1 to the number of elements of tErrors

--- a/tools/Linter.lc
+++ b/tools/Linter.lc
@@ -2,19 +2,36 @@
 
 local sErrorsList
 local sLastLine
+local sTempFile
+
 
 Lint
 
 command Lint
-  local tScope, theArgument
+  local tScope, tLCCompile, tModulePaths, theArgument
+
+  local tIndex
   repeat for each element theArgument in the commandArguments
-    if theArgument begins with "-scope" then
-       split theArgument with "="
-       put theArgument[2] into tScope
-   else if theArgument begins with "-explicitVariables" then
-      split theArgument with "="
-      set the explicitVariables to theArgument[2]
-    end if
+    split theArgument with "="
+    switch theArgument[1]
+      case "-scope"
+        put theArgument[2] into tScope
+        break
+      case "-explicitVariables"
+        set the explicitVariables to theArgument[2]
+        break
+      case "-modulePaths"
+        split theArgument[2] with ";"
+        repeat with tIndex = 1 to the number of elements in theArgument[2]
+          if there is a folder theArgument[2][tIndex] then
+            put " --modulepath " & theArgument[2][tIndex] after tModulePaths
+          end if
+        end repeat
+        break
+      case "-lcCompile"
+        put theArgument[2] into tLCCompile
+        break
+    end switch
   end repeat
 
   read from stdin until empty
@@ -26,53 +43,73 @@ command Lint
 
   create script only stack "TestScript"
 
-  if tScope is empty or tScope is ".source.livecodescript" then
-    local tLineOffset = 0
+  local tErrors
+  switch tScope
+    case ".source.livecodescript"
+      local tLineOffset = 0
 
-    -- check for script only
-    if word 1 of tScript is "script" then
-      put 1 into tLineOffset
-    end if
-
-    if tLineOffset is 1 then
-      delete line 1 of tScript
-    end if
-
-    set the script of stack "TestScript" to tScript
-
-    local theErrors
-    put the result into theErrors
-    split theErrors with return
-    local tIndex
-    repeat with tIndex = 1 to the number of elements in theErrors
-      if theErrors[tIndex] is not empty then
-        local tMessage
-        put sErrorsList[item 1 of theErrors[tIndex]] into tMessage
-        if tMessage is not empty then
-          if item 4 of theErrors[tIndex] is not empty then
-            put " (" & item 4 of theErrors[tIndex] & ")" after tMessage
-          end if
-          write item 2 of theErrors[tIndex] + tLineOffset, item 3 of theErrors[tIndex], tMessage & linefeed to stdout
-        end if
+      -- check for script only
+      if word 1 of tScript is "script" then
+        put 1 into tLineOffset
       end if
-    end repeat
-  else if tScope is ".source.iRev" then
-    -- write out to a temporary file and include
-    local tFile
-    put the temporary folder & slash & uuid() into tFile
-    -- can't lint a whole web app...
-    replace "include" with "# include" in tScript
-    replace "require" with "# require" in tScript
-    -- ensure it throws an error so it's not exectuted
-    put return & quote after tScript
-    put the number of lines of tScript into sLastLine
-    put tScript into url ("binfile:" & tFile)
-    include tFile
-  end if
 
-  write linefeed to stdout
+      if tLineOffset is 1 then
+        delete line 1 of tScript
+      end if
+
+      set the script of stack "TestScript" to tScript
+
+      put the result into tErrors
+      split tErrors with return
+      repeat with tIndex = 1 to the number of elements in tErrors
+        if tErrors[tIndex] is not empty then
+          split tErrors with ","
+          local tMessage
+          put sErrorsList[tErrors[tIndex][1]] into tMessage
+          if tMessage is not empty then
+            if tErrors[tIndex][4] is not empty then
+              put " (" & item 4 of tErrors[tIndex][4] & ")" after tMessage
+            end if
+            write tErrors[tIndex][2] + tLineOffset, tErrors[tIndex][3], tMessage & linefeed to stdout
+          end if
+        end if
+      end repeat
+    break
+    case ".source.iRev"
+        -- can't lint a whole web app...
+      replace "include" with "# include" in tScript
+      replace "require" with "# require" in tScript
+      -- ensure it throws an error so it's not exectuted
+      put return & quote after tScript
+      put the number of lines of tScript into sLastLine
+      SaveToTempFile tScript
+      include sTempFile
+    break
+    case ".source.lcb"
+      SaveToTempFile tScript
+      local tProcess
+      put shell(tLCCompile & tModulePaths & " -- " & sTempFile) into tErrors
+      split tErrors with return
+      repeat with tIndex = 1 to the number of elements of tErrors
+        split tErrors[tIndex] with ":"
+        write tErrors[tIndex][2], tErrors[tIndex][3], tErrors[tIndex][4] & linefeed to stdout
+      end repeat
+      DeleteTempFile
+    break
+ end switch
+
+ write linefeed to stdout
 
 end Lint
+
+command SaveToTempFile pScript
+  put the temporary folder & slash & uuid() into sTempFile
+  put pScript into url ("binfile:" & sTempFile)
+end SaveToTempFile
+
+command DeleteTempFile
+  delete file sTempFile
+end DeleteTempFile
 
 command scriptExecutionError pStack, pFiles
   split pStack with return
@@ -93,15 +130,7 @@ command scriptExecutionError pStack, pFiles
     end if
   end repeat
 
-  -- cleanup
-  local tFile
-  set the itemDelimiter to slash
-  repeat for each line tFile in pFiles
-    if item -1 of tFile is "Linter.lc" then
-      next repeat
-    end if
-    delete file tFile
-  end repeat
+  DeleteTempFile
 
   write linefeed to stdout
 end scriptExecutionError


### PR DESCRIPTION
@peter-b I went ahead and did it as it was easier than I anticipated ;-)

There's no dependency management other than global module paths. I think it's still useful for widget and library implementation though. To handle project specific deps I was wondering about a `.deps` file.

The `.deps` file would need to be parsed to replace the working file name with the temp file name and if it exists otherwise just use the temp file by itself. This way you could run `lc-compile <other options> --deps <file list> > .deps` to get the file. The linter would just look for the file next to the file being edited.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/peter-b/atom-language-livecode/9)

<!-- Reviewable:end -->
