### PR TITLE
Fix for issue #10

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -24,6 +24,7 @@ module.exports =
         @explicitVars = explicitVars
     path = require 'path'
     @linterPath = path.join(__dirname, '..', 'tools', 'Linter.lc')
+    @notified = false
 
   deactivate: ->
     @subscriptions.dispose()
@@ -68,6 +69,15 @@ module.exports =
         resolve(data.stdout.join(''))
       handleError = (errorObject) ->
         errorObject.handle()
+        if !@notified
+          atom.notifications.addWarning(
+            'Please check you have LiveCode Server installed correctly',
+            {
+              detail: 'LiveCode Server is required for linting your files\n' +
+              'edit the location in the package settings'
+            }
+            )
+          @notified = true
         resolve('')
       spawnedProcess = new BufferedProcess({command, args, options, stdout, stderr, exit})
       spawnedProcess.onWillThrowError(handleError)

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -1,4 +1,4 @@
-{CompositeDisposable} = require 'atom'
+{BufferedProcess, CompositeDisposable} = require 'atom'
 
 module.exports =
   config:
@@ -29,7 +29,6 @@ module.exports =
     @subscriptions.dispose()
 
   provideLinter: ->
-    helpers = require('atom-linter')
     provider =
       grammarScopes: ['source.livecodescript', 'source.iRev']
       scope: 'file'
@@ -45,7 +44,7 @@ module.exports =
         explicitVariables = '-explicitVariables=' + @explicitVars
         parameters.push(explicitVariables)
         text = textEditor.getText()
-        return helpers.exec(command, parameters, {stdin: text}).then (output) ->
+        return @exec(command, parameters, {stdin: text}).then (output) ->
           regex = /(\d+),(\d+),(.*)/g
           messages = []
           while((match = regex.exec(output)) isnt null)
@@ -59,3 +58,19 @@ module.exports =
               ]
               text: match[3]
           return messages
+
+  exec: (command, args = [], options = {}) ->
+    return new Promise (resolve, reject) ->
+      data = stdout: [], stderr: []
+      stdout = (output) -> data.stdout.push(output.toString())
+      stderr = (output) -> data.stderr.push(output.toString())
+      exit = ->
+        resolve(data.stdout.join(''))
+      handleError = (errorObject) ->
+        errorObject.handle()
+        resolve('')
+      spawnedProcess = new BufferedProcess({command, args, options, stdout, stderr, exit})
+      spawnedProcess.onWillThrowError(handleError)
+      if options.stdin
+        spawnedProcess.process.stdin.write(options.stdin.toString())
+        spawnedProcess.process.stdin.end() # We have to end it or the programs will keep waiting forever

--- a/package.json
+++ b/package.json
@@ -8,9 +8,6 @@
     "atom": "*"
   },
   "main": "./lib/main",
-  "dependencies": {
-    "atom-linter": "^3.0.0"
-  },
   "providedServices": {
     "linter": {
       "versions": {

--- a/tools/GenerateSnippets.livecodescript
+++ b/tools/GenerateSnippets.livecodescript
@@ -14,6 +14,7 @@ on mouseUp
             tab & tab & tab & "builtins:" & cr & \
             tab & tab & tab & tab & "suggestions: [" into theSnippets
 
+
       # functions
       set the folder to specialFolderPath("home") & "/livecode/docs/dictionary/function"
       repeat for each line theFile in the files

--- a/tools/GenerateSnippets.livecodescript
+++ b/tools/GenerateSnippets.livecodescript
@@ -13,7 +13,7 @@ on mouseUp
             tab & tab & "symbols:" & cr & \
             tab & tab & tab & "builtins:" & cr & \
             tab & tab & tab & tab & "suggestions: [" into theSnippets
-      
+
       # functions
       set the folder to specialFolderPath("home") & "/livecode/docs/dictionary/function"
       repeat for each line theFile in the files


### PR DESCRIPTION
This commit resolves issue #10 by silently failing if the LiveCode
Server process can not be spawned. In the process the dependency on
atom-linter was factored out as it was necessary to re-implement
helper.exec(). Rather than reject the promise as is the normal procedure
in the event of an error here I have chosen to resolve with an empty
output because it means you can fix the LiveCode Server process name
and it will start linting in the same session.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/peter-b/atom-language-livecode/11)

<!-- Reviewable:end -->
