### PR TITLE
Add HTML syntax highlighting for mixed (HTML/iRev) code

### DIFF
--- a/grammars/irev.cson
+++ b/grammars/irev.cson
@@ -5,43 +5,50 @@ fileTypes: [
 firstLineMatch: "^<\\?rev\\b|<\\?lc\\b|<\\?livecode\\b"
 foldingStartMarker: "(/\\*)|(^\\s*\\b(on|command|function|repeat|if|switch)\\s+(\\w+|\\(\\.*))|(^\\s+?try$)"
 foldingStopMarker: "(\\*/)|^\\s*\\b(end\\s+(?!if|repeat)\\w+|(end\\s+(repeat|if|switch|try)))"
+injections:
+  "text.html.iRev":
+    patterns: [
+      {
+        begin: "<\\?rev"
+        end: "\\?>"
+        patterns: [
+         {
+           include: "#language"
+         }
+        ]
+      }
+      {
+        begin: "(((?<=\\?>)<)|<)\\?(?i:rev)?"
+        beginCaptures:
+          "0":
+            name: "punctuation.section.embedded.begin.iRev"
+          "2":
+            name: "meta.consecutive-tags.iRev"
+        comment: "Catches embeded irev code."
+        end: "(\\?)>"
+        endCaptures:
+          "0":
+            name: "punctuation.section.embedded.end.iRev"
+          "1":
+            name: "source.iRev"
+        name: "source.iRev.embedded.line.html"
+        patterns: [
+          {
+            include: "#language"
+          }
+        ]
+      }
+    ]
 name: "iRev"
 patterns: [
   {
-    begin: "<\\?rev"
-    end: "\\?>"
-    patterns: [
-      {
-        include: "source.livecodescript"
-      }
-      {
-        include: "#revigniter"
-      }
-    ]
+    include: "text.html.basic"
   }
   {
-    begin: "(((?<=\\?>)<)|<)\\?(?i:rev)?"
-    beginCaptures:
-      "0":
-        name: "punctuation.section.embedded.begin.iRev"
-      "2":
-        name: "meta.consecutive-tags.iRev"
-    comment: "Catches embeded irev code."
-    end: "(\\?)>"
-    endCaptures:
-      "0":
-        name: "punctuation.section.embedded.end.iRev"
-      "1":
-        name: "source.iRev"
-    name: "source.iRev.embedded.line.html"
-    patterns: [
-      {
-        include: "source.livecodescript"
-      }
-      {
-        include: "#revigniter"
-      }
-    ]
+    include: "source.livecodescript"
+  }
+  {
+    include: "#revigniter"
   }
 ]
 repository:
@@ -56,4 +63,4 @@ repository:
         name: "support.function.iRev"
       }
     ]
-scopeName: "source.iRev"
+scopeName: "text.html.iRev"

--- a/snippets/livecode.cson
+++ b/snippets/livecode.cson
@@ -1,4 +1,4 @@
-".source.livecodescript":
+".source.livecodescript, .text.html.iRev":
   "COOKIE['...']":
     prefix: "$_"
     body: "$_COOKIE[\"${1:variable}\"]"

--- a/snippets/revigniter.cson
+++ b/snippets/revigniter.cson
@@ -1,4 +1,4 @@
-".source.iRev":
+".text.html.iRev":
   "Accept Charset":
     prefix: "riagentcharset"
     body: "rigAcceptCharset()"


### PR DESCRIPTION
This modification enables syntax highlighting for HTML code mixed with rvIgniter code.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/peter-b/atom-language-livecode/25)

<!-- Reviewable:end -->
